### PR TITLE
[Remove] jbuilderを削除

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ ruby '3.0.0'
 gem 'rails', '~> 6.1.3'
 
 gem 'bootsnap', require: false
-gem 'jbuilder'
 gem 'mysql2'
 gem 'puma'
 gem 'sass-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,8 +114,6 @@ GEM
       activesupport (>= 4.2.0)
     i18n (1.8.9)
       concurrent-ruby (~> 1.0)
-    jbuilder (2.11.2)
-      activesupport (>= 5.0.0)
     json (2.5.1)
     jwt (2.2.2)
     listen (3.4.1)
@@ -333,7 +331,6 @@ DEPENDENCIES
   bullet
   capybara
   factory_bot_rails
-  jbuilder
   listen
   mysql2
   pry-byebug


### PR DESCRIPTION
## 概要

#26 のついでに
現時点でjbuilderは不要＆scaffoldで不要な記述が書かれるので

APIを作る必要が出たときに導入を検討する