### PR TITLE
DBでcollationを`utf8mb4_bin`に指定する

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -12,6 +12,8 @@
 default: &default
   adapter: mysql2
   encoding: utf8mb4
+  charset: utf8mb4
+  collation: utf8mb4_bin
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: root
   password:

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 
 ActiveRecord::Schema.define(version: 2021_03_22_005251) do
 
-  create_table "authentications", charset: "utf8mb4", force: :cascade do |t|
+  create_table "authentications", charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "provider", null: false
     t.string "uid", null: false
@@ -22,7 +22,7 @@ ActiveRecord::Schema.define(version: 2021_03_22_005251) do
     t.index ["user_id"], name: "index_authentications_on_user_id"
   end
 
-  create_table "images", charset: "utf8mb4", force: :cascade do |t|
+  create_table "images", charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.string "title", null: false
     t.text "description"
     t.text "url", null: false
@@ -32,7 +32,7 @@ ActiveRecord::Schema.define(version: 2021_03_22_005251) do
     t.index ["product_id"], name: "index_images_on_product_id"
   end
 
-  create_table "products", charset: "utf8mb4", force: :cascade do |t|
+  create_table "products", charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.string "title", null: false
     t.text "description"
     t.string "url"
@@ -42,7 +42,7 @@ ActiveRecord::Schema.define(version: 2021_03_22_005251) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
-  create_table "user_products", charset: "utf8mb4", force: :cascade do |t|
+  create_table "user_products", charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "product_id", null: false
     t.datetime "created_at", precision: 6, null: false
@@ -51,7 +51,7 @@ ActiveRecord::Schema.define(version: 2021_03_22_005251) do
     t.index ["user_id"], name: "index_user_products_on_user_id"
   end
 
-  create_table "users", charset: "utf8mb4", force: :cascade do |t|
+  create_table "users", charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.string "display_name", null: false
     t.string "screen_name", null: false
     t.string "email", null: false


### PR DESCRIPTION
## 概要

Resolves #51

よさげ資料：[MySQLの文字コード事情 2017版](https://www.slideshare.net/tmtm/mysql-2017)

- 絵文字を区別する
- 大文字小文字を区別する
- 「ハハ」と「パパ」を区別する

なんかとにかく全文字でユニーク扱いしてくれるっぽかったので`utf8mb4_bin`にした

## お願い

@en-Barry @ShotaroHirose59 
マージ、pull後に以下の作業を行ってください！！

1. 手元の`database.yml`に、このPRで行った追記部分を追加
https://github.com/runteq/runteq_senses/blob/70a59fbac71f4fbb8fb00e741b90cce0fe0f40d9/config/database.yml#L15-L16
1. `bundle exec rails db:reset`
1. `bundle exec rails db:migrate`

これでローカルで差分が出なければOKです！！
差分が出た場合は教えてください
