### PR TITLE
フォームの表示崩れを修正

### DIFF
--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -32,5 +32,17 @@
     .text-field {
       @apply appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-gray-500;
     }
+
+    .field_with_errors {
+      display: contents;
+
+      .form-label {
+        @apply text-red-700;
+      }
+
+      .text-field {
+        @apply bg-red-200 border-red-200 focus:outline-none focus:bg-white focus:border-gray-500;
+      }
+    }
   }
 }


### PR DESCRIPTION
## 概要

before
![image](https://user-images.githubusercontent.com/44717752/116268269-1f8baa80-a7b8-11eb-806f-89b131a7c8aa.png)

after
![image](https://user-images.githubusercontent.com/44717752/116269036-d12adb80-a7b8-11eb-8e51-21e97ce64260.png)

なんかそこはかとなくダサいけどまあいいや。