### PR TITLE
[Remove]display_nameが空文字のときのrequest_specを削除

### DIFF
--- a/spec/requests/profiles_spec.rb
+++ b/spec/requests/profiles_spec.rb
@@ -43,23 +43,6 @@ RSpec.describe "/profile", type: :request do
         expect(response).to redirect_to(user_url(user.screen_name))
       end
     end
-
-    context "with invalid parameters" do
-      let(:attributes) do
-        {
-          display_name: '',
-        }
-      end
-
-      it "does not update the requested user" do
-        expect { subject }.not_to change { user.reload.display_name }.from('古い表示名')
-      end
-
-      it "renders a successful response (i.e. to display the 'edit' template)" do
-        subject
-        expect(response).to be_successful
-      end
-    end
   end
 
   describe "DELETE /destroy" do


### PR DESCRIPTION
## 概要
display_name未設定時のデフォルトを空文字に変更するため、該当部分のrequest_specを削除
