### PR TITLE
Fix:ヘッダーのレイアウトを変更

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,26 +1,24 @@
-<nav class="flex items-center justify-between flex-wrap bg-indigo-100 p-6">
+<nav class="flex items-center justify-between flex-wrap bg-indigo-100 px-4 md:h-20">
   <div class="flex items-center flex-no-shrink text-indigo-800 mr-6">
-    <span class="font-semibold text-xl tracking-tight">
+    <span class="flex items-center font-semibold text-xl tracking-tight">
       <%= link_to 'RUNTEQ senses', root_path, class: 'no-underline' %>
     </span>
   </div>
   <div>
     <div class="pr-0">
-      <div class="flex relative inline-block float-right">
+      <div class="flex relative inline-block float-right items-center">
         <%= link_to 'About', '#', class: 'btn text-indigo-800 hover:bg-indigo-200' %>
         <%= link_to 'Products', root_path, class: 'btn text-indigo-800 hover:bg-indigo-200' %>
         <%= link_to 'Users', users_path, class: 'btn text-indigo-800 hover:bg-indigo-200' %>
         <% if logged_in? %>
           <div class="relative text-sm text-gray-100">
-            <button id="userButton" class="btn items-center focus:outline-none mr-3">
-              <img class="w-10 h-10 rounded-full mr-4" src="http://i.pravatar.cc/300" alt="Avatar of User">
-            </button>
+            <img class="btn items-center focus:outline-none w-16 h-16 rounded-full" src="http://i.pravatar.cc/300" alt="Avatar of User" >
             <div id="userMenu" class="bg-white nunito rounded shadow-md absolute mt-12 top-5 right-0 min-w-full overflow-auto z-30 ">
               <ul class="list-reset">
                 <li><%= link_to 'Profile', profile_path, class: 'px-4 py-2 block text-gray-900 hover:bg-indigo-200 no-underline hover:no-underline' %></li>
                 <li><%= link_to 'Setting', '#', class: 'px-4 py-2 block text-gray-900 hover:bg-indigo-200 no-underline hover:no-underline' %></li>
                 <li>
-                    <hr class="border-t mx-2 border-gray-400">
+                  <hr class="border-t mx-2 border-gray-400">
                 </li>
                 <li><%= link_to 'Logout', logout_path, method: :delete, class: 'px-4 py-2 block text-gray-900 hover:bg-indigo-200 no-underline hover:no-underline' %></li>
               </ul>


### PR DESCRIPTION
## 概要

Resolves #101 

ヘッダーのレイアウトを画面遷移図を参考に修正

**ログイン前**
[![Image from Gyazo](https://i.gyazo.com/6a6f40c4944241549b6b6101ee93c19b.png)](https://gyazo.com/6a6f40c4944241549b6b6101ee93c19b)

**ログイン後**
[![Image from Gyazo](https://i.gyazo.com/4906ea69b7430b7309d085692c8a1df5.png)](https://gyazo.com/4906ea69b7430b7309d085692c8a1df5)




### やったこと
- ログインしている場合は、ユーザーの画像とメニューが表示される
- ログインしていない場合は、githubログインボタンが表示される

### やっていないこと
- ユーザーのドロップダウンメニューの動き

## コメント
ドロップダウンは表示/非表示の切り替えしてませんー。

投稿フォームの要素（画像・メディア）追加を実装するときに相談したいと思ってましたが、
jsは何を使うべきだと思いますか？
パッと思いつくのはこの2つなんですが。。
- jQuery
- Hotwire(stimulus)