### PR TITLE
最大文字数のバリデーションを追加する

### DIFF
--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -23,4 +23,6 @@ class Image < ApplicationRecord
   validates :product_image, attached: true,
     content_type: /\Aimage\/.*\z/,
     size: { less_than: 10.megabytes }
+  
+  validates :description, length: { maximum: 500 }
 end

--- a/app/models/medium.rb
+++ b/app/models/medium.rb
@@ -21,6 +21,7 @@
 class Medium < ApplicationRecord
   belongs_to :product
 
-  validates :title, presence: true
-  validates :url, presence: true, url: { allow_blank: true, schemes: %w[https http] }
+  validates :title, presence: true, length: { maximum: 100 }
+  validates :url, presence: true, url: { allow_blank: true, schemes: %w[https http] }, length: { maximum: 500 }
+  validates :description, length: { maximum: 500 }
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -19,10 +19,11 @@ class Product < ApplicationRecord
   has_many :product_technologies, dependent: :destroy
   has_many :technologies, through: :product_technologies
 
-  validates :title, presence: true
-  validates :url, url: { allow_blank: true, schemes: %w[https http] }
-  validates :source_url, url: { allow_blank: true, schemes: %w[https http] }
+  validates :title, presence: true, length: { maximum: 100 }
+  validates :url, url: { allow_blank: true, schemes: %w[https http] }, length: { maximum: 500 }
+  validates :source_url, url: { allow_blank: true, schemes: %w[https http] }, length: { maximum: 500 }
   validates :released_on, presence: true
+  validates :summary, length: { maximum: 500 }
 
   def permitted_edit?(user)
     !!user&.in?(users)

--- a/app/models/technology.rb
+++ b/app/models/technology.rb
@@ -17,6 +17,6 @@ class Technology < ApplicationRecord
   has_many :product_technologies, dependent: :destroy
   has_many :products, through: :product_technologies
 
-  validates :name, uniqueness: true
-  validates :slug, uniqueness: true, format: { with: /\A[a-zA-Z0-9_-]+\z/, message: "この%{attribute}%{value}はだめです" }
+  validates :name, uniqueness: true, length: { maximum: 100 }
+  validates :slug, uniqueness: true, format: { with: /\A[a-zA-Z0-9_-]+\z/, message: "この%{attribute}%{value}はだめです" }, length: { maximum: 100 }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,9 +25,9 @@ class User < ApplicationRecord
   has_many :authentications, dependent: :destroy
   accepts_nested_attributes_for :authentications
 
-  validates :display_name, presence: true
-  validates :screen_name, presence: true, uniqueness: true
-  validates :email, presence: true, uniqueness: true
+  validates :display_name, presence: true, length: { maximum: 100 }
+  validates :screen_name, presence: true, uniqueness: true, length: { maximum: 100 }
+  validates :email, presence: true, uniqueness: true, length: { maximum: 100 }
 
   enum status: { general: 0, deactivated: 10 }
 


### PR DESCRIPTION
## 概要

Resolves #68 

### やったこと
string型には`100`、text型には`500`を最大文字数として設定しました。

### バリデーション設定してない箇所
- authentication.rb
  - provider
  - uid

- user.rb
  - crypted_password
  - salt


## チェック

- [x] rubocopをパスした
- [x] specをパスした
- [x] brakemanをパスした

<!-- その他、関連Issueの受け入れ条件など -->


## コメント
よしなにやったので気になる箇所があれば修正します