### PR TITLE
[Add] 開発環境用のseedデータを追加

### DIFF
--- a/db/fixtures/development/01_user.rb
+++ b/db/fixtures/development/01_user.rb
@@ -1,0 +1,11 @@
+user_hashes = (1..20).map do |n|
+  {
+    id: n,
+    display_name: "example#{n}",
+    screen_name: "example#{n}",
+    email: "example#{n}@example.com",
+    status: :general
+  }
+end
+
+User.seed(:id, *user_hashes)

--- a/db/fixtures/development/02_product.rb
+++ b/db/fixtures/development/02_product.rb
@@ -1,0 +1,12 @@
+product_hashes = (1..20).map do |n|
+  {
+    id: n,
+    title: "いい感じのサービス#{n}",
+    summary: "革新的・革命的なサービス！\n圧倒的な素晴らしさにきっとあなたは涙する……。",
+    released_on: n.months.ago,
+    url: 'https://runteq.jp/',
+    source_url: ''
+  }
+end
+
+Product.seed(:id, *product_hashes)

--- a/db/fixtures/development/03_user_product.rb
+++ b/db/fixtures/development/03_user_product.rb
@@ -1,0 +1,9 @@
+hashes = (1..20).map do |n|
+  {
+    id: n,
+    user_id: n,
+    product_id: n
+  }
+end
+
+UserProduct.seed(:id, *hashes)


### PR DESCRIPTION
## 概要

Resolves #116

### やったこと

- User, Product, 中間テーブルのseedデータを追加


`rake db:seed_fu RAILS_ENV=test`ではuserなどが作成されないことを確認した。

![image](https://user-images.githubusercontent.com/44717752/120096965-1c922a00-c169-11eb-982d-aac3419d652e.png)
