### PR TITLE
CIのDEPRECATEDメッセージの解消

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,10 @@ commands:
       - run: bundle exec rails db:create
       - run: bundle exec rails db:schema:load
 
+  drop_tables:
+    steps:
+      - run: bundle exec rails db:drop
+
   setup_yarn:
     steps:
       - restore_cache:
@@ -121,6 +125,7 @@ jobs:
       - setup_database
       - setup_yarn
       - run_lint
+      - drop_tables
 
   test:
     executor: default_executor
@@ -134,6 +139,7 @@ jobs:
       - setup_yarn
       - build_webpack
       - run_tests
+      - drop_tables
 
 workflows:
   version: 2


### PR DESCRIPTION
```
[DEPRECATED] The `--path` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set --local path 'vendor/bundle'`, and stop using this flag
```

なぜかdevelopでは落ちるテスト
https://github.com/runteq/fledge-hub/runs/2785789128