### PR TITLE
RubyMine用の設定ファイルをgitignoreに追記

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ yarn-debug.log*
 
 # Ignore spec/examples
 /spec/examples.txt
+
+# RubyMine
+/.idea


### PR DESCRIPTION
## 概要

- RubyMine用の設定ファイルをgitignoreに追記

### やったこと

- RubyMine用の設定ファイルをgitignoreに追記

### やっていないこと


## 確認方法

- RubyMineでこのディレクトリを開き、`/.idea`直下のファイルが追加されないことを確認してください

## チェック

- [x] rubocopをパスした
- [x] specをパスした
- [x] brakemanをパスした

