### PR TITLE
新規作成ボタンをFABにした

### DIFF
--- a/app/assets/images/plus.svg
+++ b/app/assets/images/plus.svg
@@ -1,0 +1,3 @@
+<svg style="width:24px;height:24px" viewBox="0 0 24 24">
+    <path fill="white" d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z" />
+</svg>

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,4 +12,14 @@ module ApplicationHelper
   def meta_image_url(image_url = '')
     image_url.presence || 'デフォルトのOGP用URL'
   end
+
+  def embedded_svg filename, options={}
+    file = File.read(Rails.root.join('app', 'assets', 'images', filename))
+    doc = Nokogiri::HTML::DocumentFragment.parse file
+    svg = doc.at_css 'svg'
+    if options[:class].present?
+      svg['class'] = options[:class]
+    end
+    doc.to_html.html_safe
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -13,13 +13,11 @@ module ApplicationHelper
     image_url.presence || 'デフォルトのOGP用URL'
   end
 
-  def embedded_svg filename, options={}
+  def embedded_svg(filename, options = {})
     file = File.read(Rails.root.join('app', 'assets', 'images', filename))
     doc = Nokogiri::HTML::DocumentFragment.parse file
     svg = doc.at_css 'svg'
-    if options[:class].present?
-      svg['class'] = options[:class]
-    end
-    doc.to_html.html_safe
+    svg['class'] = options[:class] if options[:class].present?
+    content_tag(doc.to_html.delete_prefix('<').chop)
   end
 end

--- a/app/views/products/index.html.slim
+++ b/app/views/products/index.html.slim
@@ -1,5 +1,7 @@
-- if logged_in?
-  = link_to '新規登録', new_product_path, class: 'btn btn-indigo'
-
 .flex.flex-wrap.-mx-4
   = render(ProductComponent.with_collection(@products))
+
+- if logged_in?
+  .fixed.z-50.right-4.bottom-12.rounded-full.shadow-2xl.cursor-pointer
+    .p-4.w-14.h-14.bg-indigo-600.rounded-full.shadow-2xl.hover:bg-indigo-400.active:shadow-lg.mouse.shadow.transition.ease-in.duration-200.focus:outline-none
+      = link_to embedded_svg("plus.svg", class: "plus-icon", alt: "plus-icon"), new_product_path

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -13,7 +13,7 @@
         <% if logged_in? %>
           <div  class="relative text-sm text-gray-100" data-controller="dropdown">
             <div data-action="click->dropdown#toggle click@window->dropdown#hide" role="button" data-dropdown-target="button" tabindex="0" class="inline-block select-none">
-              <%= image_tag current_user.avatar, alt: current_user.display_name, class: 'items-center focus:outline-none w-12 h-12 rounded-full' %>
+              <%= image_tag current_user.avatar, alt: current_user.display_name, class: 'items-center focus:outline-none md:w-9 h-9 sm:w-6 h-6 rounded-full' %>
             </div>
             <div id="userMenu" data-dropdown-target="menu" class="absolute right-0 hidden">
               <div class="bg-white shadow rounded border overflow-hidden">


### PR DESCRIPTION
## 概要

Resolves #171
[![Image from Gyazo](https://i.gyazo.com/06509112120c0823692aae480301cf1c.png)](https://gyazo.com/06509112120c0823692aae480301cf1c)

### やったこと
- FAB追加した
- svgを埋め込めるようにした

### やっていないこと
- PC/SPの切り替え

Material DesignさんによるとPCのときは左上か、右下でExtendさせるかした方がええらしい。
知らんけど。
[![Image from Gyazo](https://i.gyazo.com/aa05ae2f154dc59d748923889c8d25d4.png)](https://gyazo.com/aa05ae2f154dc59d748923889c8d25d4)

[![Image from Gyazo](https://i.gyazo.com/7de0fd018f81e84cc4c7bca24262617e.png)](https://gyazo.com/7de0fd018f81e84cc4c7bca24262617e)

https://material.io/components/buttons-floating-action-button#extended-fab

## 確認方法

1. `bundle install`
1. `bundle exec rails db:migrate`
1. http://127.0.0.1:3000/ から新規プロダクトのCRUD操作を行う



## チェック

- [ ] rubocopをパスした
- [ ] specをパスした
- [ ] brakemanをパスした

<!-- その他、関連Issueの受け入れ条件など -->

