### PR TITLE
[Add] PublicAccessを利用するために追加

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -7,12 +7,13 @@ local:
   root: <%= Rails.root.join("storage") %>
 
 # Use rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
-# amazon:
-#   service: S3
-#   access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
-#   secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
-#   region: us-east-1
-#   bucket: your_own_bucket
+amazon:
+  service: S3
+  access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
+  secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
+  region: us-east-1
+  bucket: your_own_bucket
+  # public: true # リリースしたらコメントアウトを外す（PublicAccessをtrue）
 
 # Remember not to checkin your GCS keyfile to a repository
 # google:


### PR DESCRIPTION
## 概要

#130
<!-- 開発内容・変更内容を記載してください -->
<!-- 画面キャプチャもあれば貼ってください -->

### やったこと
PublicAccessを利用するためのコードを追加しました。
ただしAWS S3のバケットを設定するまで正常に動かないため、現在はコメントアウトしています。
バケット設定後、コメントアウトを解除して動作を確認する必要があります。

### やっていないこと

## 確認方法

<!-- レビュワーがどうすればローカルで確認できるか手順を書いておくと親切です -->
<!-- ローカルのURLを貼ってもいいです -->
現在は確認できないのでASW S3のバケットを設定後、コメントアウトを解除して動作を確認する必要があります。
おそらく、PublicAccess利用前の現状では、画像に設定されるURLが
```
http://localhost:3000/rails/active_storage/blobs/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBNZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--824a4edeb0c4453e69f1009f97d993962d20fda9/51ouGc6zGFL.jpg"
```
のようになっているはずですが、PublicAccess利用後は、
```
http://localhost:3000
```
にリクエストが向かないようになっていれば、正常にPublicAccessが動作していると思います。

<!-- その他、関連Issueの受け入れ条件など -->

## コメント

<!-- 実装の参考になったURLや、実装に際して気になったこと、困ったことなど -->
【参考】https://www.tech-blog.startup-technology.com/2021/6a3205978b0c3741178f/
