### PR TITLE
リリース日に応じてプロダクト詳細ページのメッセージを動的に表示する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem 'faraday'
 gem 'pagy', '~> 3.5'
 
 group :development, :test do
+  gem 'active_decorator'
   gem 'bullet'
   gem 'factory_bot_rails'
   gem 'faker'
@@ -35,7 +36,6 @@ group :development, :test do
 end
 
 group :development do
-  gem 'active_decorator'
   gem 'annotate'
   gem 'better_errors'
   gem 'binding_of_caller'

--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,7 @@ group :development do
 end
 
 group :test do
+  gem 'active_decorator-rspec'
   gem 'capybara'
   gem 'rspec_junit_formatter'
   gem 'selenium-webdriver'

--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ group :development, :test do
 end
 
 group :development do
+  gem 'active_decorator'
   gem 'annotate'
   gem 'better_errors'
   gem 'binding_of_caller'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,6 +41,11 @@ GEM
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
     active_decorator (1.4.0)
       activesupport
+    active_decorator-rspec (0.0.9)
+      actionpack
+      active_decorator
+      activesupport
+      rspec (>= 3.0)
     active_hash (3.1.0)
       activesupport (>= 5.0.0)
     active_storage_validations (0.9.5)
@@ -274,6 +279,10 @@ GEM
     regexp_parser (2.1.1)
     require_all (3.0.0)
     rexml (3.2.5)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
     rspec-core (3.10.1)
       rspec-support (~> 3.10.0)
     rspec-expectations (3.10.1)
@@ -409,6 +418,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_decorator
+  active_decorator-rspec
   active_hash
   active_storage_validations
   annotate

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,8 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_decorator (1.4.0)
+      activesupport
     active_hash (3.1.0)
       activesupport (>= 5.0.0)
     active_storage_validations (0.9.5)
@@ -406,6 +408,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  active_decorator
   active_hash
   active_storage_validations
   annotate

--- a/app/decorators/product_decorator.rb
+++ b/app/decorators/product_decorator.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+module ProductDecorator
+end

--- a/app/decorators/product_decorator.rb
+++ b/app/decorators/product_decorator.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 
 module ProductDecorator
+  def release_day_message
+    Time.zone.today < released_on ? "#{released_on} will be released" : "#{released_on} released"
+  end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -47,4 +47,8 @@ class Product < ApplicationRecord
   def user
     @user ||= users.take
   end
+
+  def release_day_message
+    Time.zone.today < released_on ? "#{released_on} will be released" : "#{released_on} released"
+  end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -47,8 +47,4 @@ class Product < ApplicationRecord
   def user
     @user ||= users.take
   end
-
-  def release_day_message
-    Time.zone.today < released_on ? "#{released_on} will be released" : "#{released_on} released"
-  end
 end

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -6,7 +6,7 @@
   <div class="flex flex-col space-y-4 lg:space-y-0 lg:flex-row lg:items-center lg:justify-between">
     <div>
       <span class="text-gray-400">
-        <%= "#{@product.released_on} Released" %>
+        <%= @product.release_day_message %>
       </span>
       <div class="flex flex-col mt-2 space-y-1 sm:flex-row sm:space-y-0 sm:items-center sm:space-x-4">
         <h3 class="text-2xl font-semibold text-gray-800 dark:text-gray-200">

--- a/spec/decorators/product_decorator_spec.rb
+++ b/spec/decorators/product_decorator_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ProductDecorator do
+  let(:product) { Product.new.extend ProductDecorator }
+  subject { product }
+  it { should be_a Product }
+end

--- a/spec/decorators/product_decorator_spec.rb
+++ b/spec/decorators/product_decorator_spec.rb
@@ -2,8 +2,27 @@
 
 require 'rails_helper'
 
-RSpec.describe ProductDecorator do
-  let(:product) { Product.new.extend ProductDecorator }
-  subject { product }
-  it { should be_a Product }
+RSpec.describe ProductDecorator, type: :decorator do
+  describe '#release_day_message' do
+    context 'リリース日が昨日の場合' do
+      let(:product) { create(:product, :yesterday) }
+      it 'releasedと表示される' do
+        expect( decorate(product).release_day_message ).to eq "#{product.released_on} released"
+      end
+    end
+
+    context 'リリース日が今日の場合' do
+      let(:product) { create(:product, :today) }
+      it 'releasedと表示される' do
+        expect( decorate(product).release_day_message ).to eq "#{product.released_on} released"
+      end
+    end
+
+    context 'リリース日が明日の場合' do
+      let(:product) { create(:product, :tomorrow) }
+      it 'will be releasedと表示される' do
+        expect( decorate(product).release_day_message ).to eq "#{product.released_on} will be released"
+      end
+    end
+  end
 end

--- a/spec/decorators/product_decorator_spec.rb
+++ b/spec/decorators/product_decorator_spec.rb
@@ -7,21 +7,22 @@ RSpec.describe ProductDecorator, type: :decorator do
     context 'リリース日が昨日の場合' do
       let(:product) { create(:product, :yesterday) }
       it 'releasedと表示される' do
-        expect( decorate(product).release_day_message ).to eq "#{product.released_on} released"
+        expect(decorate(product).release_day_message).to eq "#{product.released_on} released"
       end
     end
 
     context 'リリース日が今日の場合' do
       let(:product) { create(:product, :today) }
       it 'releasedと表示される' do
-        expect( decorate(product).release_day_message ).to eq "#{product.released_on} released"
+        expect(decorate(product).release_day_message).to eq "#{product.released_on} released"
       end
     end
 
     context 'リリース日が明日の場合' do
       let(:product) { create(:product, :tomorrow) }
-      it 'will be releasedと表示される' do
-        expect( decorate(product).release_day_message ).to eq "#{product.released_on} will be released"
+      fit 'will be releasedと表示される' do
+        expect(decorate(product).release_day_message).to \
+          eq "#{product.released_on} will be released"
       end
     end
   end

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -22,5 +22,17 @@ FactoryBot.define do
     released_on { Time.zone.today }
     product_type_id { ProductType.pluck(:id).sample }
     product_category_id { ProductCategory.pluck(:id).sample }
+
+    trait :yesterday do
+      released_on { Time.zone.yesterday }
+    end
+
+    trait :today do
+      released_on { Time.zone.today }
+    end
+
+    trait :tomorrow do
+      released_on { Time.zone.tomorrow }
+    end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,6 +9,7 @@ require 'factory_bot'
 require 'view_component/test_helpers'
 require 'capybara/rspec'
 # Add additional requires below this line. Rails is not loaded until this point!
+require 'active_decorator/rspec'
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are


### PR DESCRIPTION
## 概要
プロダクト詳細ページのリリース日の後に続くメッセージを、リリース日が今日以前であれば「released」に、リリース日が未来であれば「will be released」と動的に表示されるように修正し、テストを書きました。

Resolves #135
<!-- 開発内容・変更内容を記載してください -->
<!-- 画面キャプチャもあれば貼ってください -->
![yesterday_product](https://user-images.githubusercontent.com/72296262/128662598-89abfbd4-e128-468a-a3cb-4254a7908357.png)
![today_product](https://user-images.githubusercontent.com/72296262/128662647-5d058330-9f2c-41eb-964a-614cc9c9f950.png)
![tomorrow_product](https://user-images.githubusercontent.com/72296262/128662695-395ff415-1eb5-4731-a3ce-f6aefade9aeb.png)

### やったこと
- decoratorを導入
- 今日と比較してリリース日が未来であれば「will be released」、今日以前であれば「released」と動的に表示するメソッドをdecoratorに実装
- テストを記述

### やっていないこと


## 確認方法

- リリース日が昨日、今日、明日のプロダクトを作成し、それぞれのメッセージの表記が「released」「will be released」「will be released」となるかを確認してください。
- product_decorator_spec.rbに記述したテストが通ることを確認してください。

## コメント

<!-- 実装の参考になったURLや、実装に際して気になったこと、困ったことなど -->
