### PR TITLE
500エラー調査

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -38,7 +38,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :amazon
+  config.active_storage.service = :local
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -13,7 +13,7 @@ Rails.application.configure do
   config.eager_load = true
 
   # Full error reports are disabled and caching is turned on.
-  config.consider_all_requests_local       = false
+  config.consider_all_requests_local       = true
   config.action_controller.perform_caching = true
 
   # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -13,7 +13,7 @@ Rails.application.configure do
   config.eager_load = true
 
   # Full error reports are disabled and caching is turned on.
-  config.consider_all_requests_local       = true
+  config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true
 
   # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]


### PR DESCRIPTION
## 概要
S3設定後のデプロイがようやくできた(IAMにS3のポリシー付与を忘れてました<(_ _)>)が、本番で500エラーが発生してる。

前回の500エラーは #226 で対応したが、デプロイ時の挙動が未確認だった。

なのでS3設定の有無で発生してる500エラーなのかを調査する

## ログ
ログは正常か

```
[runteq@ip-10-0-11-30 log]$ tail production.log
I, [2021-08-21T14:25:41.834447 #1123]  INFO -- : [c4cacc41-36a4-4e6d-8524-6cbdcbd02fb6] Started GET "/" for 10.0.12.74 at 2021-08-21 14:25:41 +0000
I, [2021-08-21T14:25:41.835085 #1123]  INFO -- : [c4cacc41-36a4-4e6d-8524-6cbdcbd02fb6] Processing by ProductsController#index as HTML
I, [2021-08-21T14:25:41.842193 #1123]  INFO -- : [c4cacc41-36a4-4e6d-8524-6cbdcbd02fb6]   Rendered products/index.html.slim within layouts/application (Duration: 5.0ms | Allocations: 446)
I, [2021-08-21T14:25:41.843629 #1123]  INFO -- : [c4cacc41-36a4-4e6d-8524-6cbdcbd02fb6]   Rendered layout layouts/application.html.slim (Duration: 6.5ms | Allocations: 1073)
I, [2021-08-21T14:25:41.843901 #1123]  INFO -- : [c4cacc41-36a4-4e6d-8524-6cbdcbd02fb6] Completed 200 OK in 9ms (Views: 3.0ms | ActiveRecord: 4.4ms | Allocations: 1594)
I, [2021-08-21T14:25:43.616465 #1123]  INFO -- : [022f3c01-1c45-4064-aff7-6ff452cafac5] Started GET "/" for 10.0.11.111 at 2021-08-21 14:25:43 +0000
I, [2021-08-21T14:25:43.617091 #1123]  INFO -- : [022f3c01-1c45-4064-aff7-6ff452cafac5] Processing by ProductsController#index as HTML
I, [2021-08-21T14:25:43.620632 #1123]  INFO -- : [022f3c01-1c45-4064-aff7-6ff452cafac5]   Rendered products/index.html.slim within layouts/application (Duration: 1.4ms | Allocations: 446)
I, [2021-08-21T14:25:43.621905 #1123]  INFO -- : [022f3c01-1c45-4064-aff7-6ff452cafac5]   Rendered layout layouts/application.html.slim (Duration: 2.7ms | Allocations: 1072)
I, [2021-08-21T14:25:43.622135 #1123]  INFO -- : [022f3c01-1c45-4064-aff7-6ff452cafac5] Completed 200 OK in 5ms (Views: 2.6ms | ActiveRecord: 1.0ms | Allocations: 1576)
```

コンソールで502エラー出てるけど`Bad Gateway`の画面じゃないからNigixの問題ではない？
[![Image from Gyazo](https://t.gyazo.com/teams/startup-technology/174867471c513ecfd06c735d3bc13d00.png)](https://startup-technology.gyazo.com/174867471c513ecfd06c735d3bc13d00)

## デプロイ履歴
- d83c9a9 でS3を無効にしたが500エラーのまま --> S3関係なさそう

