### PR TITLE
検索フォームを拡張して、プロダクト形式・カテゴリで検索できるようにした

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -55,6 +55,7 @@ Metrics/AbcSize:
 
 Metrics/BlockLength:
   Exclude:
+    - "config/routes.rb"
     - "spec/**/*"
     - "lib/tasks/auto_annotate_models.rake"
     - "config/environments/development.rb"

--- a/app/components/product_component.html.slim
+++ b/app/components/product_component.html.slim
@@ -14,9 +14,11 @@
       .flex.items-center.flex-wrap
         .inline-flex.tracking-widest.text-sm.title-font.font-medium.text-gray-400
           = product.released_on
-        span.inline-flex.ml-auto.px-2.text-xs.leading-5.font-semibold.bg-yellow-100.text-yellow-900.mb-2
+        = link_to search_path(q: { product_type_id: product.product_type_id }),
+                  class: 'inline-flex no-underline ml-auto mb-2 px-2 text-xs leading-5 font-semibold bg-yellow-100 text-yellow-900' do
           = product.product_type.name
-        span.inline-flex.ml-2.px-2.text-xs.leading-5.font-semibold.bg-red-100.text-red-900.mb-2
+        = link_to search_path(q: { product_category_id: product.product_category_id }),
+                  class: 'inline-flex no-underline ml-2 mb-2 px-2 text-xs leading-5 font-semibold bg-yellow-100 text-yellow-900' do
           = product.product_category.name
       h2.title-font.text-lg.font-bold.text-gray-900
         = link_to product.title, product_path(product), class: 'no-underline'
@@ -29,7 +31,10 @@
 
       .flex.items-center.flex-wrap
         - if @product.url.present?
-          = link_to sanitize(@product.url), class: 'text-indigo-500 inline-flex items-center md:mb-2 lg:mb-0 no-underline font-bold', target: '_blank', rel: 'noopener noreferrer' do
+          = link_to sanitize(@product.url),
+                    class: 'text-indigo-500 inline-flex items-center md:mb-2 lg:mb-0 no-underline font-bold',
+                    target: '_blank',
+                    rel: 'noopener noreferrer' do
             | Go WebSite
             i class="fas fa-caret-right ml-2"
         span.text-gray-400.inline-flex.lg:ml-auto.md:ml-0.ml-auto.leading-none.text-sm.py-1

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::Base
+  include Pagy::Backend
+
   protected
 
   def not_authenticated

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,6 +1,5 @@
 class ProductsController < ApplicationController
   before_action :require_login, only: %i[new edit create update destroy]
-  include Pagy::Backend
 
   def index
     @search_form = SearchProductsForm.new(search_params)

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -2,11 +2,10 @@ class ProductsController < ApplicationController
   before_action :require_login, only: %i[new edit create update destroy]
 
   def index
-    @search_form = SearchProductsForm.new(search_params)
-    @pagy, @products = pagy(@search_form.search
-                            .includes(:technologies,
-                                      :users, { images: { product_image_attachment: :blob } })
-                            .order(created_at: :desc))
+    products = Product.includes(:technologies,
+                                :users, { images: { product_image_attachment: :blob } })
+                      .order(created_at: :desc)
+    @pagy, @products = pagy(products)
   end
 
   def show
@@ -60,9 +59,5 @@ class ProductsController < ApplicationController
       technology_ids: [],
       media_attributes: %i[id title url],
     )
-  end
-
-  def search_params
-    params.fetch(:search, {}).permit(:title)
   end
 end

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -1,10 +1,9 @@
 class SearchesController < ApplicationController
   def show
-    search_form = SearchProductsForm.new(search_params)
-    products = search_form.search
-                          .includes(:technologies,
-                                    :users, { images: { product_image_attachment: :blob } })
-                          .order(created_at: :desc)
+    search_result = SearchProductsForm.search(search_params)
+    products = search_result.includes(:technologies,
+                                      :users, { images: { product_image_attachment: :blob } })
+                            .order(created_at: :desc)
     @pagy, @products = pagy(products)
   end
 

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -1,0 +1,16 @@
+class SearchesController < ApplicationController
+  def show
+    search_form = SearchProductsForm.new(search_params)
+    products = search_form.search
+                          .includes(:technologies,
+                                    :users, { images: { product_image_attachment: :blob } })
+                          .order(created_at: :desc)
+    @pagy, @products = pagy(products)
+  end
+
+  private
+
+  def search_params
+    params.fetch(:q, {}).permit(:title)
+  end
+end

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -10,6 +10,6 @@ class SearchesController < ApplicationController
   private
 
   def search_params
-    params.fetch(:q, {}).permit(:title)
+    params.fetch(:q, {}).permit(:title, :product_type_id, :product_category_id)
   end
 end

--- a/app/forms/search_products_form.rb
+++ b/app/forms/search_products_form.rb
@@ -1,11 +1,16 @@
 class SearchProductsForm
   include ActiveModel::Model
+  include ActiveModel::Attributes
   include KanaHelper
 
-  attr_accessor :title
+  attribute :title, :string, default: ''
+
+  def self.search(args)
+    new(args).search
+  end
 
   def search
-    relation = Product
+    relation = Product.all
     relation = search_title(relation) if title.present?
     relation
   end

--- a/app/forms/search_products_form.rb
+++ b/app/forms/search_products_form.rb
@@ -4,6 +4,8 @@ class SearchProductsForm
   include KanaHelper
 
   attribute :title, :string, default: ''
+  attribute :product_type_id, :integer, default: ''
+  attribute :product_category_id, :string, default: ''
 
   def self.search(args)
     new(args).search
@@ -12,6 +14,8 @@ class SearchProductsForm
   def search
     relation = Product.all
     relation = search_title(relation) if title.present?
+    relation = search_product_type(relation) if product_type_id.present?
+    relation = search_product_category(relation) if product_category_id.present?
     relation
   end
 
@@ -22,5 +26,13 @@ class SearchProductsForm
     like_katakana = "%#{to_katakana(title)}%"
 
     relation.where('title LIKE ? or title LIKE ?', like_hiragana, like_katakana)
+  end
+
+  def search_product_type(relation)
+    relation.where(product_type_id: product_type_id)
+  end
+
+  def search_product_category(relation)
+    relation.where(product_category_id: product_category_id)
   end
 end

--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -28,7 +28,7 @@
     </div>
     <%= f.date_field :released_on, required: true, class: 'text-field' %>
   </div>
-  
+
   <div class='form-group'>
     <%= f.label :url, class: 'form-label' %>
     <%= f.text_field :url, class: 'text-field' %>
@@ -45,21 +45,21 @@
   <div class='form-group'>
     <div class='form-group inline-flex w-1/2 px-1'>
       <div class='form-label'>
-        <div style='display: flex; align-items: center;'>
-          <%= f.label :product_category_id %>
-          <p class='required'>必須</p>
-        </div>
-      </div>
-      <%= f.select :product_category_id, ProductCategory.asc.pluck(:name, :id), { required: true, prompt: '選択してください' }, class: 'select-box' %>
-    </div>
-    <div class='form-group inline-flex w-1/2 px-1'>
-      <div class='form-label'>
-        <div style='display: flex; align-items: center;'>
+        <div class='flex items-center'>
           <%= f.label :product_type_id %>
           <p class='required'>必須</p>
         </div>
       </div>
       <%= f.select :product_type_id, ProductType.asc.pluck(:name, :id), { required: true, prompt: '選択してください' }, class: 'select-box' %>
+    </div>
+    <div class='form-group inline-flex w-1/2 px-1'>
+      <div class='form-label'>
+        <div class='flex items-center'>
+          <%= f.label :product_category_id %>
+          <p class='required'>必須</p>
+        </div>
+      </div>
+      <%= f.select :product_category_id, ProductCategory.asc.pluck(:name, :id), { required: true, prompt: '選択してください' }, class: 'select-box' %>
     </div>
   </div>
   <div class='form-group'>

--- a/app/views/products/index.html.slim
+++ b/app/views/products/index.html.slim
@@ -1,10 +1,8 @@
-= render 'search_form'
+= render 'searches/form'
 
 .flex.flex-wrap.-mx-4
-  - if @products.present?
-    = render(ProductComponent.with_collection(@products))
-  - else
-    p.mt-10.mx-auto 検索条件を満たすサービスはありませんでした
+  = render(ProductComponent.with_collection(@products))
+
 == pagy_nav(@pagy)
 
 - if logged_in?

--- a/app/views/searches/_form.html.slim
+++ b/app/views/searches/_form.html.slim
@@ -1,7 +1,7 @@
 .w-full.md:w-5/12.mx-auto.mb-4
   = form_with model: @search_form,
-              url: root_path, method: :get,
-              scope: 'search',
+              url: search_path, method: :get,
+              scope: 'q',
               data: { turbo: false },
               class: 'w-full flex',
               local: true do |f|

--- a/app/views/searches/_form.html.slim
+++ b/app/views/searches/_form.html.slim
@@ -5,6 +5,7 @@
               data: { turbo: false },
               class: 'w-full flex',
               local: true do |f|
-    = f.text_field :title, class: 'w-full pl-4 pr-8 outline-none h-10 rounded-full border'
+    = f.text_field :title, value: params.dig(:q, :title),
+                           class: 'w-full pl-4 pr-8 outline-none h-10 rounded-full border'
     = f.button content_tag(:i, '', class: 'fas fa-search text-gray-600 h-4 w-4 fill-current'),
       class: 'ml-1 outline-none focus:outline-none relative right-8 -mr-8'

--- a/app/views/searches/show.html.slim
+++ b/app/views/searches/show.html.slim
@@ -1,0 +1,10 @@
+= render 'form'
+
+.flex.flex-wrap.-mx-4
+  - if @products.present?
+    = render(ProductComponent.with_collection(@products))
+  - else
+    p.mt-10.mx-auto
+      | 条件を満たすサービスはありませんでした
+
+== pagy_nav(@pagy)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,7 @@ Rails.application.routes.draw do
   resources :products, only: %i[show new edit create update destroy] do
     resources :product_images, only: %i[new create edit update destroy]
   end
+  resource :search, only: %i[show]
 
   resources :users, only: %i[index show], param: :screen_name
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,9 @@
 Rails.application.routes.draw do
   root 'products#index'
-  resources :users, only: %i[index show], param: :screen_name
+  get '/terms', to: 'static_pages#terms'
+  get 'inquiry', to: 'inquiries#new', as: :new_inquiry
+  resource :inquiry, only: %i[create]
+
   resource :mypage, only: %i[show]
   namespace :settings do
     resource :profile, only: %i[show update]
@@ -10,19 +13,19 @@ Rails.application.routes.draw do
       end
     end
   end
+
   resource :registration, only: %i[new create]
   resource :user_deactivation, only: %i[new destroy]
-  resource :inquiry, only: %i[create]
-  resources :products, only: %i[show new edit create update destroy] do
-    resources :product_images, only: %i[new create edit update destroy]
-  end
-
-  get '/terms', to: 'static_pages#terms'
-  get 'inquiry', to: 'inquiries#new', as: :new_inquiry
   post 'oauth/callback', to: 'oauths#callback'
   get 'oauth/callback', to: 'oauths#callback'
   get 'oauth/:provider', to: 'oauths#oauth', as: :auth_at_provider
   delete 'logout', to: 'user_sessions#destroy', as: :logout
+
+  resources :products, only: %i[show new edit create update destroy] do
+    resources :product_images, only: %i[new create edit update destroy]
+  end
+
+  resources :users, only: %i[index show], param: :screen_name
 
   # 開発/テスト用ログイン
   get '/login_as/:user_id', to: 'development/sessions#login_as' unless Rails.env.production?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,8 @@ Rails.application.routes.draw do
   end
 
   resource :registration, only: %i[new create]
-  resource :user_deactivation, only: %i[new destroy]
+  resource :user_deactivation, only: %i[destroy]
+  get 'deactivation', to: 'user_deactivations#new', as: :new_user_deactivation
   post 'oauth/callback', to: 'oauths#callback'
   get 'oauth/callback', to: 'oauths#callback'
   get 'oauth/:provider', to: 'oauths#oauth', as: :auth_at_provider

--- a/spec/components/product_component_spec.rb
+++ b/spec/components/product_component_spec.rb
@@ -2,8 +2,7 @@ require 'rails_helper'
 
 RSpec.describe ProductComponent, type: :component do
   context 'productが存在する時' do
-    let(:user) { create(:user) }
-    let(:product) { create(:product, users: [user]) }
+    let!(:product) { create(:product, :with_user) }
     it 'ComponentにProductのtitleが含まれていること' do
       render_inline(described_class.new(product: product))
       expect(rendered_component).to have_text product.title

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -23,6 +23,12 @@ FactoryBot.define do
     product_type_id { ProductType.pluck(:id).sample }
     product_category_id { ProductCategory.pluck(:id).sample }
 
+    trait :with_user do
+      after(:build) do |product|
+        create(:user, products: [product])
+      end
+    end
+
     trait :yesterday do
       released_on { Time.zone.yesterday }
     end

--- a/spec/forms/search_products_form_spec.rb
+++ b/spec/forms/search_products_form_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe SearchProductsForm do
   describe '#search_title' do
-    subject { SearchProductsForm.new(title: title).search }
+    subject { SearchProductsForm.search(title: title) }
 
     before do
       create(:product, title: 'ぷろだくと')

--- a/spec/forms/search_products_form_spec.rb
+++ b/spec/forms/search_products_form_spec.rb
@@ -42,4 +42,21 @@ RSpec.describe SearchProductsForm do
       end
     end
   end
+
+  describe '#search_product_type, #search_product_category' do
+    subject do
+      SearchProductsForm.search(
+        product_type_id: 1,
+        product_category_id: 1,
+      )
+    end
+    let!(:target_product) { create(:product, product_type_id: 1, product_category_id: 1) }
+    let!(:_non_type_product) { create(:product, product_type_id: 2, product_category_id: 1) }
+    let!(:_non_category_product) { create(:product, product_type_id: 1, product_category_id: 2) }
+    let!(:_non_searched_product) { create(:product, product_type_id: 2, product_category_id: 2) }
+
+    it 'どちらの条件も満たしたプロダクトのみ返す' do
+      expect(subject.length).to eq 1
+    end
+  end
 end

--- a/spec/forms/search_products_form_spec.rb
+++ b/spec/forms/search_products_form_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe SearchProductsForm do
-  describe '.search' do
-    subject { SearchProductsForm.new(title: title).search.length }
+  describe '#search_title' do
+    subject { SearchProductsForm.new(title: title).search }
 
     before do
       create(:product, title: 'ぷろだくと')
@@ -14,7 +14,7 @@ RSpec.describe SearchProductsForm do
       let!(:title) { 'ぷろだくと' }
 
       it 'ひらがな・カタカナを問わず検索されること' do
-        expect(subject).to eq 2
+        expect(subject.length).to eq 2
       end
     end
 
@@ -22,7 +22,7 @@ RSpec.describe SearchProductsForm do
       let!(:title) { 'プロダクト' }
 
       it 'ひらがな・カタカナを問わず検索されること' do
-        expect(subject).to eq 2
+        expect(subject.length).to eq 2
       end
     end
 
@@ -30,7 +30,7 @@ RSpec.describe SearchProductsForm do
       let!(:title) { 'ダク' }
 
       it '検索名を含むプロダクトが検索されること' do
-        expect(subject).to eq 2
+        expect(subject.length).to eq 2
       end
     end
 
@@ -38,7 +38,7 @@ RSpec.describe SearchProductsForm do
       let!(:title) { 'ヒットせず' }
 
       it '何のプロダクトも返らないこと' do
-        expect(subject).to eq 0
+        expect(subject.length).to eq 0
       end
     end
   end

--- a/spec/requests/products_spec.rb
+++ b/spec/requests/products_spec.rb
@@ -1,10 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe ProductsController, type: :request do
-  let(:user) { create(:user) }
-
   describe 'GET /show' do
-    let(:product) { create(:product, users: [user]) }
+    let(:product) { create(:product, :with_user) }
     subject { get product_url(product) }
 
     it 'renders a successful response' do
@@ -14,6 +12,7 @@ RSpec.describe ProductsController, type: :request do
   end
 
   describe 'GET /new' do
+    let!(:user) { create(:user) }
     subject { get '/products/new' }
     before { login_as(user) }
 
@@ -24,7 +23,8 @@ RSpec.describe ProductsController, type: :request do
   end
 
   describe 'GET /edit' do
-    let(:product) { create(:product, users: [user]) }
+    let!(:user) { create(:user) }
+    let!(:product) { create(:product, users: [user]) }
     subject { get "/products/#{product.id}/edit" }
     before { login_as(user) }
 
@@ -35,6 +35,7 @@ RSpec.describe ProductsController, type: :request do
   end
 
   describe 'POST /create' do
+    let!(:user) { create(:user) }
     before { login_as(user) }
     subject { post '/products', params: { product: attributes } }
 
@@ -64,7 +65,7 @@ RSpec.describe ProductsController, type: :request do
 
     context 'with technology_ids' do
       let!(:technology) { create(:technology) }
-      let(:attributes) do
+      let!(:attributes) do
         {
           title: 'hoge',
           summary: '',
@@ -87,7 +88,7 @@ RSpec.describe ProductsController, type: :request do
     end
 
     context 'with invalid parameters' do
-      let(:attributes) do
+      let!(:attributes) do
         {
           title: 'hoge',
         }
@@ -105,12 +106,13 @@ RSpec.describe ProductsController, type: :request do
   end
 
   describe 'PATCH /update' do
+    let!(:user) { create(:user) }
     subject { patch "/products/#{product.id}", params: { product: attributes } }
     before { login_as(user) }
 
     context 'with valid parameters' do
       let!(:product) { create(:product, title: 'hoge', users: [user]) }
-      let(:attributes) do
+      let!(:attributes) do
         {
           title: 'foo',
         }
@@ -132,7 +134,7 @@ RSpec.describe ProductsController, type: :request do
       let!(:product) do
         create(:product, title: 'hoge', users: [user], technologies: [previous_technology])
       end
-      let(:attributes) do
+      let!(:attributes) do
         {
           title: 'hoge',
           summary: '',
@@ -154,7 +156,7 @@ RSpec.describe ProductsController, type: :request do
 
     context 'with invalid parameters' do
       let!(:product) { create(:product, title: 'hoge', users: [user]) }
-      let(:attributes) do
+      let!(:attributes) do
         {
           title: '',
         }
@@ -172,6 +174,7 @@ RSpec.describe ProductsController, type: :request do
   end
 
   describe 'DELETE /destroy' do
+    let!(:user) { create(:user) }
     let!(:product) { create(:product, users: [user]) }
     subject { delete "/products/#{product.id}" }
     before { login_as(user) }

--- a/spec/requests/searches_spec.rb
+++ b/spec/requests/searches_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe SearchesController, type: :request do
+  describe 'GET /show' do
+    let!(:params) {
+      {
+        q: {
+          title: 'サービス名'
+        }
+      }
+    }
+    subject { get search_url(params) }
+
+    it 'renders a successful response' do
+      create(:product, title: '検索されない') # usersが存在しないので、描画されるとエラーになる
+      create(:product, :with_user, title: 'サービス名')
+      subject
+      expect(response).to be_successful
+    end
+  end
+end

--- a/spec/requests/searches_spec.rb
+++ b/spec/requests/searches_spec.rb
@@ -2,13 +2,13 @@ require 'rails_helper'
 
 RSpec.describe SearchesController, type: :request do
   describe 'GET /show' do
-    let!(:params) {
+    let!(:params) do
       {
         q: {
-          title: 'サービス名'
-        }
+          title: 'サービス名',
+        },
       }
-    }
+    end
     subject { get search_url(params) }
 
     it 'renders a successful response' do

--- a/spec/requests/user_deactivations_spec.rb
+++ b/spec/requests/user_deactivations_spec.rb
@@ -8,14 +8,14 @@ RSpec.describe UserDeactivationsController, type: :request do
     context 'ユーザーのサービスがあるとき' do
       it 'returns http success' do
         create(:product, users: [user])
-        get '/user_deactivation/new'
+        get '/deactivation'
         expect(response).to have_http_status(:success)
       end
     end
 
     context 'ユーザーのサービスがないとき' do
       it 'returns http success' do
-        get '/user_deactivation/new'
+        get '/deactivation'
         expect(response).to have_http_status(:success)
       end
     end


### PR DESCRIPTION
## 概要

Resolves #257

![image](https://user-images.githubusercontent.com/44717752/132247261-503f8f2a-0cd9-4a12-968b-750af1c93dda.png)

![image](https://user-images.githubusercontent.com/44717752/132247228-139b458f-418d-4f24-90cd-7755a2bbbec9.png)


### やったこと

- 検索結果のURLを別にした
- リファクタリング
- カテゴリ・プロダクト形式で検索できるようにした
- タグにリンクを貼った

### やっていないこと

- 検索内容の表示
