### PR TITLE
細々した修正

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -40,7 +40,7 @@ class ProductsController < ApplicationController
   def destroy
     @product = current_user.products.find(params[:id])
     @product.destroy!
-    redirect_to products_url, notice: 'サービスを削除しました！'
+    redirect_to root_url, notice: 'サービスを削除しました！'
   end
 
   private

--- a/app/forms/inquiry_form.rb
+++ b/app/forms/inquiry_form.rb
@@ -23,7 +23,7 @@ class InquiryForm
   private
 
   def text
-    "| name | #{name} |\n | -- | -- |\n | email | #{email} |\n | about | #{about}|\n | description | #{description}|\n | user_agent | #{user_agent}|"
+    "| name | #{name} |\n | -- | -- |\n | email | #{email} |\n | about | #{about}|\n | user_agent | #{user_agent}|\n#{description}"
   end
 
   def save_inquiry!

--- a/app/forms/product_form.rb
+++ b/app/forms/product_form.rb
@@ -145,7 +145,7 @@ class ProductForm
 
   def url_validity
     ogp_url
-  rescue SocketError
+  rescue SocketError, Net::OpenTimeout
     errors.add(:url, 'にアクセスできません。')
   end
 

--- a/spec/forms/inquiry_form_spec.rb
+++ b/spec/forms/inquiry_form_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe InquiryForm do
         expect(MattermostNotifier).to receive(:call).with(
           channel: 'fledge-hub',
           username: 'お問い合わせ',
-          text: "| name | name_test |\n | -- | -- |\n | email | test@example.com |\n | about | about_test|\n | description | description_test|\n | user_agent | user_agent_test|",
+          text: "| name | name_test |\n | -- | -- |\n | email | test@example.com |\n | about | about_test|\n | user_agent | user_agent_test|\ndescription_test",
         )
         subject
       end

--- a/spec/requests/products_spec.rb
+++ b/spec/requests/products_spec.rb
@@ -189,7 +189,7 @@ RSpec.describe ProductsController, type: :request do
 
     it 'redirects to the products list' do
       subject
-      expect(response).to redirect_to(products_url)
+      expect(response).to redirect_to(root_url)
     end
   end
 end


### PR DESCRIPTION
## 概要

- 無効なパスを修正
- お問い合わせの本文だけテーブルの外に出す

![image](https://user-images.githubusercontent.com/44717752/133532918-06f899bc-0d08-42b4-b57c-64f9754ac6dc.png)

- OGP取得のときに無効なURLはrescueすることにする