### PR TITLE
技術タグが折り返すときにきれいに表示されるように・検索ボタンを中央に・検索時はturbo無効

### DIFF
--- a/app/components/product_component.html.slim
+++ b/app/components/product_component.html.slim
@@ -20,13 +20,13 @@
           = product.product_category.name
       h2.title-font.text-lg.font-bold.text-gray-900
         = link_to product.title, product_path(product), class: 'no-underline'
-      .mb-1.mx-1
+      .mb-1.mx-1.flex.flex-wrap.items-center.gap-x-2
         - product.technologies.each_with_index do |technology, index|
           = link_to root_path(q: { technologies_id_eq_any: technology.id }), class: 'no-underline' do
-            span.py-1.text-xs.leading-5.text-gray-500
+            div.py-1.text-xs.leading-5.text-gray-500
               = technology.name
           - if index != product.technologies.size - 1
-            span class="mx-2 text-xs text-indigo-400"
+            div class="text-xs text-indigo-400 inline-flex"
               | /
 
       .flex.items-center.flex-wrap

--- a/app/views/inquiries/new.html.slim
+++ b/app/views/inquiries/new.html.slim
@@ -1,6 +1,6 @@
 - set_meta_tags title: 'お問い合わせ'
 
-= form_with model: @inquiry_form, url: inquiry_path, class: 'form', data: { turbo: false } do |f|
+= form_with model: @inquiry_form, url: inquiry_path, class: 'form' do |f|
   - if f.object.errors.any?
     ul
       - @inquiry_form.errors.full_messages.each do |message|

--- a/app/views/products/index.html.slim
+++ b/app/views/products/index.html.slim
@@ -16,5 +16,5 @@
 
 .fixed.z-50.right-4.bottom-12.rounded-full.shadow-2xl.cursor-pointer
   = link_to new_search_path do
-    .p-5.w-14.h-14.bg-indigo-600.rounded-full.shadow-2xl.hover:bg-indigo-400.active:shadow-lg.mouse.shadow.duration-200.focus:outline-none
+    .px-5.py-4.w-14.h-14.bg-indigo-600.rounded-full.shadow-2xl.hover:bg-indigo-400.active:shadow-lg.mouse.shadow.duration-200.focus:outline-none
       i class='fas fa-search text-white'

--- a/app/views/searches/new.html.slim
+++ b/app/views/searches/new.html.slim
@@ -7,7 +7,8 @@
 
 .my-4.z-20
   .w-full.md:w-5/12.mx-auto
-    = search_form_for @q, url: root_path, method: :get, class: 'form' do |f|
+    - # 検索→ブラウザの「戻る」→再検索ができないのでturbo: false
+    = search_form_for @q, url: root_path, method: :get, class: 'form', data: { turbo: false } do |f|
       .form-group
         .form-label
           = Product.human_attribute_name(:product_category_id)


### PR DESCRIPTION
## 概要

![image](https://user-images.githubusercontent.com/44717752/136948847-22e8ddae-6981-41ed-bd52-3bb8c9e9f8a3.png)
