### PR TITLE
RUNTEQ広告をファーストビューに配置する

### DIFF
--- a/app/components/product_component.html.slim
+++ b/app/components/product_component.html.slim
@@ -34,3 +34,6 @@
         div
           = link_to_if product.user.active?, product.user.display_name, user_path(product.user.screen_name)
           = ' 他' if product.users.size > 1
+
+- if product_counter == 4
+  = render(RunteqAdComponent.new)

--- a/app/components/product_component.rb
+++ b/app/components/product_component.rb
@@ -3,12 +3,13 @@
 class ProductComponent < ViewComponent::Base
   include ApplicationHelper
 
-  def initialize(product:)
+  def initialize(product:, product_counter:)
     super()
     @product = product
+    @product_counter = product_counter
   end
 
   private
 
-  attr_reader :product
+  attr_reader :product, :product_counter
 end

--- a/app/components/runteq_ad_component.html.slim
+++ b/app/components/runteq_ad_component.html.slim
@@ -1,0 +1,15 @@
+.h-full.border-opacity-60.overflow-hidden
+  = link_to 'https://runteq.jp/r/vpdCdyNc', target: :_blank, rel: 'noopener noreferrer' do
+    .relative.group.rounded-lg.shadow-md
+      div class="w-full h-full absolute opacity-0 group-hover:opacity-100"
+        div class="w-full h-full bg-black bg-opacity-30 rounded-lg flex justify-center items-center"
+          div class="rounded-full h-10 w-10 bg-black bg-opacity-80 flex items-center justify-center"
+            i class="fas fa-chevron-right text-white pl-1" aria-hidden="true"
+      div class="w-full"
+        = image_tag '/images/ad_runteq.png', alt: 'RUNTEQ', class: 'rounded-lg'
+  .pt-3.pb-4
+    .flex.items-center.flex-wrap
+      .inline-flex.tracking-widest.text-sm.title-font.font-medium.text-gray-400
+        | 広告
+    h2.title-font.text-lg.font-bold.text-gray-900
+      = link_to_blank 'プログラミングスクールならRUNTEQ', 'https://runteq.jp/r/vpdCdyNc', class: 'no-underline'

--- a/app/components/runteq_ad_component.rb
+++ b/app/components/runteq_ad_component.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class RunteqAdComponent < ViewComponent::Base
+  include LinkHelper
+end

--- a/app/views/products/index.html.slim
+++ b/app/views/products/index.html.slim
@@ -2,23 +2,6 @@
   .my-3.grid.md:grid-cols-3.grid-cols-1.gap-x-8.gap-y-12
     = render(ProductComponent.with_collection(@products))
 
-    - # RUNTEQ広告↓
-    .h-full.border-opacity-60.overflow-hidden
-      = link_to 'https://runteq.jp/r/vpdCdyNc', target: :_blank, rel: 'noopener noreferrer' do
-        .relative.group.rounded-lg.shadow-md
-          div class="w-full h-full absolute opacity-0 group-hover:opacity-100"
-            div class="w-full h-full bg-black bg-opacity-30 rounded-lg flex justify-center items-center"
-              div class="rounded-full h-10 w-10 bg-black bg-opacity-80 flex items-center justify-center"
-                i class="fas fa-chevron-right text-white pl-1" aria-hidden="true"
-          div class="w-full"
-            = image_tag '/images/ad_runteq.png', alt: 'RUNTEQ', class: 'rounded-lg'
-      .pt-3.pb-4
-        .flex.items-center.flex-wrap
-          .inline-flex.tracking-widest.text-sm.title-font.font-medium.text-gray-400
-            | 広告
-        h2.title-font.text-lg.font-bold.text-gray-900
-          = link_to_blank 'プログラミングスクールならRUNTEQ', 'https://runteq.jp/r/vpdCdyNc', class: 'no-underline'
-
   .mt-10.mb-10.md:mb-0
     == pagy_nav(@pagy)
 

--- a/spec/components/product_component_spec.rb
+++ b/spec/components/product_component_spec.rb
@@ -4,8 +4,15 @@ RSpec.describe ProductComponent, type: :component do
   context 'productが存在する時' do
     let!(:product) { create(:product, :with_user) }
     it 'ComponentにProductのtitleが含まれていること' do
-      render_inline(described_class.new(product: product))
+      render_inline(described_class.new(product: product, product_counter: nil))
       expect(rendered_component).to have_text product.title
+    end
+  end
+  context '4番目の要素の時' do
+    let!(:product) { create(:product, :with_user) }
+    it 'Componentに広告表示が含まれていること' do
+      render_inline(described_class.new(product: product, product_counter: 4))
+      expect(rendered_component).to have_text 'プログラミングスクールならRUNTEQ'
     end
   end
 end

--- a/spec/components/runteq_ad_component_spec.rb
+++ b/spec/components/runteq_ad_component_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe RunteqAdComponent, type: :component do
+  it 'ComponentにRUNTEQのURLが含まれていること' do
+    render_inline(described_class.new)
+    expect(rendered_component).to have_link("プログラミングスクールならRUNTEQ")
+  end
+end

--- a/spec/components/runteq_ad_component_spec.rb
+++ b/spec/components/runteq_ad_component_spec.rb
@@ -3,6 +3,6 @@ require 'rails_helper'
 RSpec.describe RunteqAdComponent, type: :component do
   it 'ComponentにRUNTEQのURLが含まれていること' do
     render_inline(described_class.new)
-    expect(rendered_component).to have_link("プログラミングスクールならRUNTEQ")
+    expect(rendered_component).to have_link('プログラミングスクールならRUNTEQ')
   end
 end


### PR DESCRIPTION
## 概要
- RUNTEQ広告をトップページのファーストビューに配置するようにしました

[![Image from Gyazo](https://t.gyazo.com/teams/startup-technology/4ede472884c188f0cd6c45497dd0902d.png)](https://startup-technology.gyazo.com/4ede472884c188f0cd6c45497dd0902d)

### やったこと
- 広告用のViewComponentを追加
- プロダクト一覧用のページの4番目のコンポーネントの後に広告用のComponentを表示する様に変更
- プロダクト用のcomponentに変更を加えたのでRSpecを修正
- プロダクト用のRSpecに広告表示をチェックするテストケースを追加

## 確認方法
[](http://127.0.0.1:3000/)にアクセスして各ページネーションのファーストビューに広告が表示されているか確認してください

## チェック

- [x] rubocopをパスした
- [x] specをパスした
- [x] brakemanをパスした
