### PR TITLE
サービス終了のお知らせを追加

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ executors:
   default_executor:
     working_directory: ~/fledge-hub-circleci
     docker:
-      - image: circleci/ruby:3.0.2-node-browsers
+      - image: cimg/ruby:3.0.2-browsers
         environment:
           DB_HOST: 127.0.0.1
           RAILS_ENV: test

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -29,3 +29,7 @@
     <% end %>
   </div>
 </header>
+<div class="bg-orange-100 border-l-4 border-orange-500 text-orange-700 p-4" role="alert">
+  <p class="font-bold">Fledge Hubは2024年9月29日をもちましてサービスを終了いたします。</p>
+  <p>ご利用いただきました皆様、本当にありがとうございました。終了までの期間も引き続きよろしくお願いいたします。</p>
+</div>


### PR DESCRIPTION
## 概要

Resolves #
9/29のサービス終了に向けての対応

検証ツールでHTMLを埋め込んで作成した画面イメージです
[![Image from Gyazo](https://t.gyazo.com/teams/startup-technology/35e239bc3fdc26084254283af6cc1ede.jpg)](https://startup-technology.gyazo.com/35e239bc3fdc26084254283af6cc1ede)

開発環境
[![Image from Gyazo](https://t.gyazo.com/teams/startup-technology/f2562999678a11d5f134b477cf6133ae.png)](https://startup-technology.gyazo.com/f2562999678a11d5f134b477cf6133ae)

### やったこと
- ユーザーに向けてサービス終了の案内追加

### やっていないこと
- 新規登録機能の停止は対応しなくてよいとの判断とのことなのでやらないことになりました


## 確認方法
1. http://127.0.0.1:3000/ の画面を確認する



## チェック

- [x] rubocopをパスした
- [x] specをパスした
- [x] brakemanをパスした


## コメント

